### PR TITLE
Compile tetris example without the stub

### DIFF
--- a/tetris_v.v
+++ b/tetris_v.v
@@ -465,8 +465,7 @@ fn (g &Game) draw_field() {
 
 fn (g &Game) draw_text(x int, y int, text string, rr int, gg int, bb int) {
 	tcol := SdlColor {u8(3), u8(2), u8(1), u8(0)}
-	tsurf := *voidptr(0xbadfeed)
-	C.stubTTF_RenderText_Solid(g.font,text.str, &tcol, &tsurf)
+	tsurf := C.TTF_RenderText_Solid(g.font, text.str, tcol)
 	ttext := C.SDL_CreateTextureFromSurface(g.sdl.renderer, tsurf)
 	texw := 0
 	texh := 0

--- a/vsdl/vsdl.v
+++ b/vsdl/vsdl.v
@@ -4,8 +4,7 @@
 
 module vsdl
 
-#flag linux -lSDL2
-#flag -I/usr/include/SDL2 -D_REENTRANT
+#flag linux `sdl2-config --cflags --libs`  -lSDL2_ttf
 #include <SDL.h>
 #include <SDL_ttf.h>
 

--- a/vsdl/vsdl.v
+++ b/vsdl/vsdl.v
@@ -23,7 +23,9 @@ fn C.SDL_PollEvent(voidptr) int
 //fn C.TTF_OpenFont(a byteptr, b int) voidptr
 //type SdlColor struct
 
-struct SdlColor{
+struct C.TTF_Font { }
+
+struct C.SDL_Color{
 pub:
         r u8
         g u8
@@ -46,7 +48,7 @@ struct SdlColor {
 type SdlScancode int    // TODO define the real enum here
 type SdlKeycode i32
 type SdlRect SdlRect
-type SdlColor SdlColor
+type SdlColor C.SDL_Color
 type SdlSurface SdlSurface
 
 struct SdlQuitEvent {


### PR DESCRIPTION
With this PR, 
tetris compiles and runs by `v run tetris_v.v` on linux, 
without manually invoking the C compiler.

Example:
![runing tetris](https://url4e.com/gyazo/images/9be584e7.png)